### PR TITLE
feat(json-schema): add validation options for removeAdditional()

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,43 @@ export function test(input: any): ApiResponse|never {
 ```
 
 To strip additional properties from an object to ensure it matches the JSON schema definition:
+
+> Note: you must use `additionalProperties: false` or similar to have properties be removed, since otherwise they will still be valid properties
+
+```ts
+import { ApiResponse } from '../dto/ApiResponse'
+
+export function removeAdditonalProperties(input: ApiResponse): ApiResponse|never {
+  // This mutates (and returns) the input object.
+  // Properties not allowed in the JSON schema have been removed.
+  // By default, any unrelated validation issues (e.g. missing required props, invalid types) are ignored.
+  // Validation issues unrelated to additionalProperties can be surfaced using either `errorLogger` or `strict` option (see below).
+  return ApiResponse.removeAdditional(input)
+}
+```
+
+
+##### `errorLogger` option
+
+```ts
+import { ApiResponse } from '../dto/ApiResponse'
+
+export function removeAdditonalProperties(input: ApiResponse): ApiResponse|never {
+  // Pass a function to log validation errors unrelated to additionalProperties with.
+  return ApiResponse.removeAdditional(input, { errorLogger: console.log })
+}
+```
+
+##### `strict` option
+
 ```ts
 import { ApiResponse, RemoveAdditionalPropsError } from '../dto/ApiResponse'
 
 export function removeAdditonalProperties(input: ApiResponse): ApiResponse|never {
   try {
-    // This mutates (and returns) the input object
-    ApiResponse.removeAdditional(input)
+    // Set `strict` to true to throw a RemoveAdditionalPropsError if there are validation
+    // errors unrelated to additionalProperties.
+    ApiResponse.removeAdditional(input, { strict: true })
   } catch (e: unknown) {
     if (e instanceof RemoveAdditionalPropsError) {
       console.error(`error removing additional props: ${e.message}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This includes a behavioral change where `removeAdditional()` would previously throw if it encountered a validation error unrelated to removing additional properties.

The default behavior has been changed so that validation errors unrelated to `additionalProperties` will no longer throw, and additional properties not allowed under the schema's`additionalProperties` will still be removed.

You can surface unrelated validation errors using one of the two new options:
- `strict`: set to `true` to throw if there are validation errors unrelated to `additionalProperties`
- `errorLogger`: pass a logger function to ensure that any validation errors unrelated to `additionalProperties` are logged

See the new README updates for example usage.