### PR TITLE
feat(json-schema): add logger option to removeAdditional and ensure it doesn't throw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -57,6 +57,7 @@ export class JSONSchema {
 
   removeAdditional<T>(o: T, options: {
     strict?: boolean
+    logger?: { error: (s: string) => void }
     errorLogger?: (s: string) => void
   } = {}): T|never {
     // This mutates the object by removing properties that aren't in the schema
@@ -68,8 +69,16 @@ export class JSONSchema {
     )
 
     if (!valid) {
-      if (options.errorLogger) {
-        options.errorLogger(`Invalid object found when using removeAdditional(): ${JSON.stringify(error.validationErrors.map((err: any) => `${err?.schemaPath}: ${err?.message}`))}`)
+      try {
+        const message = `Invalid object found when using removeAdditional(): ${JSON.stringify(error.validationErrors.map((err: any) => `${err?.schemaPath}: ${err?.message}`))}`
+
+        if (options.errorLogger) {
+          options.errorLogger(message)
+        } else if (options.logger?.error) {
+          options.logger.error(message)
+        }
+      } catch (e) {
+        // invalid logger
       }
 
       if (options.strict) {


### PR DESCRIPTION
Adds the ability to pass a `logger` object that has an `error` method instead of an `errorLogger` function. This can be useful when a call to class method needs access to the object it is from because of internal references to `this`. To take advantage of this ability, update calls like this
```
schema.removeAdditional(o, { errorLogger: logger.error })
```
to be
```
schema.removeAdditional(o, { logger: logger })
```

Additionally, this PR ensures that if `logger.error` or `errorLogger` has a problem and throws, the call to `removeAdditional()` will not throw.