### PR TITLE
feat(json-schema): add support for oneOf discriminator

### DIFF
--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -3,10 +3,12 @@ import addFormats from 'ajv-formats'
 import { RemoveAdditionalPropsError } from './errors/remove-additional-props.error'
 
 export const ajv = addFormats(new Ajv({
+  discriminator: true,
   strictSchema: false
 }))
 
 export const ajvRemoveAdditional = addFormats(new Ajv({
+  discriminator: true,
   strictSchema: false,
   removeAdditional: true, // for more info see https://ajv.js.org/guide/modifying-data.html
   allErrors: true,


### PR DESCRIPTION
This gives ajv the ability to use a `discriminator` property to narrow down the schema to use when using the `oneOf` property, which provides better error messages that are specific to only a single sub-schema.