### PR TITLE
feat(json-schema): return error message from schema x-validation-message property

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ export interface ApiResponse {
 class ApiResponseSchema extends JSONSchema {
   constructor() {
     super({
-      "x-message": "This is a custom error message that will be returned when validation fails"
+      "x-validation-message": "This is a custom error message that will be returned when validation fails"
       "type": "object",
       "properties": {
         "code": {
@@ -139,7 +139,7 @@ export function test(input: any): ApiResponse|never {
 }
 ```
 
-##### Using a custom `x-message` property in a schema
+##### Using a custom `x-validation-message` property in a schema
 
 ```ts
 import { ApiResponse } from '../dto/ApiResponse'
@@ -149,7 +149,7 @@ export function test(input: any): ApiResponse|never {
 
   if (!valid) {
     throw new Error(JSON.stringify({
-      message: customMessage, // This message comes from the "x-message" property on the schema
+      message: customMessage, // This message comes from the "x-validation-message" property on the schema
       errors
     }))
   }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ export interface ApiResponse {
 class ApiResponseSchema extends JSONSchema {
   constructor() {
     super({
+      "x-message": "This is a custom error message that will be returned when validation fails"
       "type": "object",
       "properties": {
         "code": {
@@ -131,6 +132,26 @@ export function test(input: any): ApiResponse|never {
 
   if (!valid) {
     throw new Error(JSON.stringify(errors))
+  }
+
+  // Since it is a valid ApiResponse object, we can confidently cast it the expected type
+  return input as ApiResponse
+}
+```
+
+##### Using a custom `x-message` property in a schema
+
+```ts
+import { ApiResponse } from '../dto/ApiResponse'
+
+export function test(input: any): ApiResponse|never {
+  const {valid, errors, customMessage} = ApiResponse.validate(input)
+
+  if (!valid) {
+    throw new Error(JSON.stringify({
+      message: customMessage, // This message comes from the "x-message" property on the schema
+      errors
+    }))
   }
 
   // Since it is a valid ApiResponse object, we can confidently cast it the expected type

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -228,10 +228,10 @@ describe('JSONSchema', () => {
       expect(jsonSchema.validate({ data: 'data:image/png;base64,hello' }).valid).toBe(true)
     })
 
-    it('accepts x-message property', () => {
+    it('accepts x-validation-message property', () => {
       const jsonSchema = new JSONSchema({
         type: 'string',
-        'x-message': 'This is the error message that can be accessed when failing validation'
+        'x-validation-message': 'This is the error message that can be accessed when failing validation'
       })
 
       const { valid, customMessage } = jsonSchema.validate(false)

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -228,6 +228,17 @@ describe('JSONSchema', () => {
       expect(jsonSchema.validate({ data: 'data:image/png;base64,hello' }).valid).toBe(true)
     })
 
+    it('accepts x-message property', () => {
+      const jsonSchema = new JSONSchema({
+        type: 'string',
+        'x-message': 'This is the error message that can be accessed when failing validation'
+      })
+
+      const { valid, customMessage } = jsonSchema.validate(false)
+      expect(valid).toBe(false)
+      expect(customMessage).toBe('This is the error message that can be accessed when failing validation')
+    })
+
     it('includes error information in the output object', () => {
       const jsonSchema = new JSONSchema({
         type: 'object',

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -55,7 +55,7 @@ export class JSONSchema {
     return {
       valid,
       errors: this._validate.errors,
-      customMessage: this._schema['x-message']
+      customMessage: this._schema['x-validation-message']
     }
   }
 

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -18,6 +18,7 @@ export const ajvRemoveAdditional = addFormats(new Ajv({
 export interface ValidationResult {
   valid: boolean
   errors: ErrorObject<string, Record<string, any>, unknown>[] | null | undefined
+  customMessage: string
 }
 
 /*
@@ -53,7 +54,8 @@ export class JSONSchema {
 
     return {
       valid,
-      errors: this._validate.errors
+      errors: this._validate.errors,
+      customMessage: this._schema['x-message']
     }
   }
 


### PR DESCRIPTION
If validation fails, try to include a message from the failing schemas `x-message` property, if it exists. This allows custom error messages to be stored directly in source schemas.