### PR TITLE
feat(json-schema): include typed output in validation result

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,15 @@ You can import the generated DTO into your program and use it like this:
 import { ApiResponse } from '../dto/ApiResponse'
 
 export function test(input: any): ApiResponse|never {
-  const {valid, errors} = ApiResponse.validate(input)
+  const {valid, errors, output} = ApiResponse.validate(input)
 
   if (!valid) {
     throw new Error(JSON.stringify(errors))
   }
 
-  // Since it is a valid ApiResponse object, we can confidently cast it the expected type
-  return input as ApiResponse
+  // The output is a valid ApiResponse object, and has been coerced to the correct
+  // type within the .validate() method
+  return output
 }
 ```
 

--- a/example/dto/petstore/ApiResponse.ts
+++ b/example/dto/petstore/ApiResponse.ts
@@ -15,7 +15,7 @@ export interface ApiResponse {
 }
 
 
-class ApiResponseSchema extends JSONSchema {
+class ApiResponseSchema extends JSONSchema<ApiResponse> {
   constructor() {
     super({
       "type": "object",

--- a/example/dto/petstore/Category.ts
+++ b/example/dto/petstore/Category.ts
@@ -14,7 +14,7 @@ export interface Category {
 }
 
 
-class CategorySchema extends JSONSchema {
+class CategorySchema extends JSONSchema<Category> {
   constructor() {
     super({
       "type": "object",

--- a/example/dto/petstore/Order.ts
+++ b/example/dto/petstore/Order.ts
@@ -21,7 +21,7 @@ export interface Order {
 }
 
 
-class OrderSchema extends JSONSchema {
+class OrderSchema extends JSONSchema<Order> {
   constructor() {
     super({
       "type": "object",

--- a/example/dto/petstore/Pet.ts
+++ b/example/dto/petstore/Pet.ts
@@ -29,7 +29,7 @@ export interface Pet {
 }
 
 
-class PetSchema extends JSONSchema {
+class PetSchema extends JSONSchema<Pet> {
   constructor() {
     super({
       "type": "object",

--- a/example/dto/petstore/Tag.ts
+++ b/example/dto/petstore/Tag.ts
@@ -14,7 +14,7 @@ export interface Tag {
 }
 
 
-class TagSchema extends JSONSchema {
+class TagSchema extends JSONSchema<Tag> {
   constructor() {
     super({
       "type": "object",

--- a/example/dto/petstore/User.ts
+++ b/example/dto/petstore/User.ts
@@ -23,7 +23,7 @@ export interface User {
 }
 
 
-class UserSchema extends JSONSchema {
+class UserSchema extends JSONSchema<User> {
   constructor() {
     super({
       "type": "object",

--- a/src/cli/dto/gen-dto.ts
+++ b/src/cli/dto/gen-dto.ts
@@ -50,7 +50,7 @@ import { JSONSchema } from '@kong/brij'
 
 ${generatedTsInteface}${typeKeyAlias ? `\n${typeKeyAlias}`: ''}
 
-class ${codifiedKey}Schema extends JSONSchema {
+class ${codifiedKey}Schema extends JSONSchema<${key}> {
   constructor() {
     super(${schemaText.split('\n').join('\n    ')})
   }

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -484,9 +484,9 @@ describe('JSONSchema', () => {
         'x-validation-message': 'This is the error message that can be accessed when failing validation'
       })
 
-      const { valid, customMessage } = jsonSchema.validate(false)
-      expect(valid).toBe(false)
-      expect(customMessage).toBe('This is the error message that can be accessed when failing validation')
+      const result = jsonSchema.validate(false)
+      expect(result.valid).toBe(false)
+      result.valid === false && expect(result.customMessage).toBe('This is the error message that can be accessed when failing validation')
     })
 
     it('includes error information in the output object', () => {

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -556,6 +556,35 @@ describe('JSONSchema', () => {
         },
       ])
     })
+    it('includes a typed reference to the input in the output', () => {
+      type MySpecialType = { in: 'out' }
+
+      const jsonSchema = new JSONSchema<MySpecialType>({
+        type: 'object',
+        required: ['in'],
+        properties: {
+          in: {
+            type: 'string',
+            enum: [ 'out' ]
+          }
+        }
+      })
+
+      const input = { in: 'out' }
+
+      const result = jsonSchema.validate(input)
+
+      expect(result.valid).toEqual(true)
+
+      // Use a conditional on valid to narrow the result type down for the TS compiler.
+      // The conditional will always be true if the tests are passing.
+      if (result.valid) {
+        // This is a compile-time test to ensure that result.output is of type MySpecialType
+        const typedOutput: MySpecialType = result.output
+
+        expect(typedOutput).toBe(input)
+      }
+    })
   })
 
   describe('removeAdditional', () => {

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -22,10 +22,14 @@ export const ajvRemoveAdditional = addFormats(new Ajv({
 }))
 
 
-export interface ValidationResult {
-  valid: boolean
+export type ValidationResult<T> = {
+  valid: false
   errors: ErrorObject<string, Record<string, any>, unknown>[] | null | undefined
   customMessage: string
+} | {
+  valid: true
+  errors: undefined
+  output: T
 }
 
 /*
@@ -35,7 +39,7 @@ export interface ValidationResult {
 
  * Provides methods for validation and removal of extra properies not allowed in the schema
  */
-export class JSONSchema {
+export class JSONSchema<T=any> {
   private static _ajv: Ajv | null = null
 
   private static _ajvRemoveAdditional: Ajv | null = null
@@ -176,9 +180,18 @@ export class JSONSchema {
    * @param o 
    * @returns ValidationResult
    */
-  validate(o: any): ValidationResult {
+  validate(o: any): ValidationResult<T> {
     const validateFunction = this.validateFunction
     const valid = validateFunction(o)
+
+    if (valid) {
+      return {
+        valid,
+        errors: undefined,
+        output: o as T,
+      }
+
+    }
 
     return {
       valid,


### PR DESCRIPTION
This adds to the `.validate()` method so it also returns a typed `output` property that has been coerced to the generic type of the JSONSchema instance. This makes it so that after using the `.validate()` method, the caller does not have to do their own type coercion, and can rely on it being done automatically by referencing the `output` property.