### PR TITLE
feat(gen-dto): add exported type alias based on schema key

### DIFF
--- a/example/dto/example1/SharedObj1.ts
+++ b/example/dto/example1/SharedObj1.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+/**
+ * This file was automatically generated.
+ * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema in the source OAS file,
+ * and use `yarn brij dto` to regenerate this file.
+ */
+
+import { JSONSchema } from '@kong/brij'
+
+export interface SharedObj1 {
+  [k: string]: unknown
+}
+
+
+class SharedObj1Schema extends JSONSchema {
+  constructor() {
+    super({
+      "title": "SharedObj1",
+      "type": "object"
+    })
+  }
+}
+
+export const SharedObj1 = new SharedObj1Schema()

--- a/example/dto/example1/Test1Response.ts
+++ b/example/dto/example1/Test1Response.ts
@@ -1,0 +1,25 @@
+/* eslint-disable */
+/**
+ * This file was automatically generated.
+ * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema in the source OAS file,
+ * and use `yarn brij dto` to regenerate this file.
+ */
+
+import { JSONSchema } from '@kong/brij'
+
+export interface SharedObj1 {
+  [k: string]: unknown
+}
+
+export type Test1Response = SharedObj1
+
+class Test1ResponseSchema extends JSONSchema {
+  constructor() {
+    super({
+      "title": "SharedObj1",
+      "type": "object"
+    })
+  }
+}
+
+export const Test1Response = new Test1ResponseSchema()

--- a/example/dto/example1/index.ts
+++ b/example/dto/example1/index.ts
@@ -1,0 +1,2 @@
+export * from './SharedObj1'
+export * from './Test1Response'

--- a/example/oas/example1.json
+++ b/example/oas/example1.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Brij OAS Example 1",
+    "version": "0.0.1",
+    "title": "Example 1"
+  },
+  "paths": {
+    "/test1": {
+      "put": {
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Test1"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "Test1": {
+        "schema": {
+          "$ref": "#/components/schemas/Test1Response"
+        }
+      }
+    },
+    "schemas": {
+      "SharedObj1": {
+        "title": "SharedObj1",
+        "type": "object"
+      },
+      "Test1Response": {
+        "$ref": "#/components/schemas/SharedObj1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "ts-node ./src/cli/run.ts",
     "dev:watch": "nodemon --ignore example/ --exec \"ts-node\" ./src/cli/run.ts",
-    "example:dto": "yarn dev dto example/oas example/dto --schemas '\\#/definitions'",
+    "example:dto": "yarn dev dto example/oas example/dto --schemas '\\#/definitions' && yarn dev dto example/oas example/dto --schemas '\\#/components/schemas'",
     "example:dto:watch": "yarn dev:watch dto example/oas example/dto --schemas '\\#/definitions'",
     "build": "tsc -p tsconfig.build.json",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/dto/gen-dto.test.ts
+++ b/src/cli/dto/gen-dto.test.ts
@@ -1,0 +1,32 @@
+import { GenDTO } from "./gen-dto"
+
+describe('GenDTO', () => {
+  describe('renderTypeScriptDTO', () => {
+    it('uses the schema title as the name of an interface for types that are single-object based', async () => {
+      const rendered = await GenDTO.renderTypeScriptDTO({ title: 'Hello', type: 'object' }, 'Goodbye')
+
+      expect(rendered.split('\n')).toContain('export interface Hello {')
+    })
+
+    it('uses the schema title as the name of a type for types that are not single-object based', async () => {
+      const rendered = await GenDTO.renderTypeScriptDTO({ title: 'Hello', type: 'string' }, 'Goodbye')
+
+      expect(rendered.split('\n')).toContain('export type Hello = string')
+    })
+
+    it.each([
+      ['interface definition', { title: 'Hello', type: 'object' }, 'Goodbye'], // generated type uses `interface`
+      ['type definition', { title: 'Hello', type: 'string' }, 'Goodbye'], // generated type uses `type`
+    ])('includes a type alias if the schema title and key do not match - %s', async (_, ...args) => {
+      const rendered = await GenDTO.renderTypeScriptDTO(...args)
+
+      expect(rendered.split('\n')).toContain('export type Goodbye = Hello')
+    })
+
+    it('does not include a type alias if the schema title and key match', async () => {
+      const rendered = await GenDTO.renderTypeScriptDTO({ title: 'Hello', type: 'object' }, 'Hello')
+
+      expect(rendered.split('\n')).not.toContain('export type Hello = Hello')
+    })
+  })
+})


### PR DESCRIPTION
If the schema `title` and key do not match, then the generated types will use `title`. In this case, to ensure there is a type and a validator instance that have the same name, we export an alias of the generated type named after the schema key.