### PR TITLE
  feat(json-schema): report multiple validation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -264,6 +264,48 @@ describe('JSONSchema', () => {
         schemaPath: '#/properties/created_at/type',
       }])
     })
+
+    it('reports multiple errors', () => {
+      const jsonSchema = new JSONSchema({
+        type: 'object',
+        required: [ 'a', 'b' ],
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+          c: { type: 'string' },
+        }
+      })
+
+      expect(jsonSchema.validate({ c: true }).errors).toEqual([
+        {
+          instancePath: '',
+          keyword: 'required',
+          message: 'must have required property \'a\'',
+          params: {
+            missingProperty: 'a',
+          },
+          schemaPath: '#/required',
+        },
+        {
+          instancePath: '',
+          keyword: 'required',
+          message: 'must have required property \'b\'',
+          params: {
+            missingProperty: 'b',
+          },
+          schemaPath: '#/required',
+        },
+        {
+          instancePath: '/c',
+          keyword: 'type',
+          message: 'must be string',
+          params: {
+            type: 'string',
+          },
+          schemaPath: '#/properties/c/type',
+        },
+      ])
+    })
   })
 
   describe('removeAdditional', () => {

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -4,7 +4,8 @@ import { RemoveAdditionalPropsError } from './errors/remove-additional-props.err
 
 export const ajv = addFormats(new Ajv({
   discriminator: true,
-  strictSchema: false
+  strictSchema: false,
+  allErrors: true,
 }))
 
 export const ajvRemoveAdditional = addFormats(new Ajv({


### PR DESCRIPTION
This enables the `ajv` option `allErrors` (https://ajv.js.org/options.html#allerrors) to report multiple validation errors instead of stopping and failing after the first error.