### PR TITLE
fix(gen-dto): normalize title identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/dto/gen-dto.test.ts
+++ b/src/cli/dto/gen-dto.test.ts
@@ -23,10 +23,30 @@ describe('GenDTO', () => {
       expect(rendered.split('\n')).toContain('export type Goodbye = Hello')
     })
 
+    it.each([
+      ['HelloThere', { title: 'Hello there', type: 'string' }, 'Goodbye'],
+      ['Abc', { title: 'abc', type: 'string' }, 'Goodbye'],
+      ['Good1Yeah', { title: 'good 1 yeah', type: 'string' }, 'Goodbye'],
+      ['ReallyGreat1', { title: 'really Great 1', type: 'string' }, 'Goodbye'],
+      ['Good1AnotherYeah', { title: 'good. #1 & another ; yeah?', type: 'string' }, 'Goodbye'],
+      ['UnderScore', { title: 'under_score', type: 'string' }, 'Goodbye'],
+      ['SlashDash', { title: '/slash-dash', type: 'string' }, 'Goodbye'],
+    ])('creates a valid identifier from the title for the type alias - %s', async (expected, ...args) => {
+      const rendered = await GenDTO.renderTypeScriptDTO(...args)
+
+      expect(rendered.split('\n')).toContain(`export type Goodbye = ${expected}`)
+    })
+
     it('does not include a type alias if the schema title and key match', async () => {
       const rendered = await GenDTO.renderTypeScriptDTO({ title: 'Hello', type: 'object' }, 'Hello')
 
       expect(rendered.split('\n')).not.toContain('export type Hello = Hello')
+    })
+
+    it('does not include a type alias if the schema title resolves to the same identifier as the key', async () => {
+      const rendered = await GenDTO.renderTypeScriptDTO({ title: 'Hello in there', type: 'object' }, 'HelloInThere')
+
+      expect(rendered.split('\n')).not.toContain('export type Hello = HelloInThere')
     })
   })
 })

--- a/src/cli/dto/gen-dto.ts
+++ b/src/cli/dto/gen-dto.ts
@@ -34,7 +34,7 @@ export class GenDTO {
     // of the input schema
     const identifier = GenDTO.makeCodeIdentifier(jsonSchema.title)
 
-    const typeKeyAlias = identifier && identifier !== key
+    const typeKeyAlias = identifier && identifier !== key && generatedTsInteface.includes(identifier)
       ? `export type ${key} = ${identifier}`
       : undefined
 

--- a/src/cli/dto/gen-dto.ts
+++ b/src/cli/dto/gen-dto.ts
@@ -32,8 +32,10 @@ export class GenDTO {
     // If the resolved schema title did not match the key (also if the schema was using a $ref),
     // export a type alias for the generated schema type so that it can be referenced by the key
     // of the input schema
-    const typeKeyAlias = jsonSchema.title && jsonSchema.title !== key
-      ? `export type ${key} = ${jsonSchema.title}`
+    const identifier = GenDTO.makeCodeIdentifier(jsonSchema.title)
+
+    const typeKeyAlias = identifier && identifier !== key
+      ? `export type ${key} = ${identifier}`
       : undefined
 
     return `/* eslint-disable */
@@ -92,6 +94,21 @@ export const ${key} = new ${key}Schema()
     const indexPath = path.join(args.outputDirectory, 'index.ts')
 
     fs.writeFileSync(indexPath, args.indexExportFiles.map(writeExport).join('\n') + '\n')
+  }
+
+  private static makeCodeIdentifier(s: string) {
+    if (!s) {
+      return ''
+    }
+
+    return s
+      .replace(/\s+/g, ' ')
+      .replace(/\_+/g, ' ')
+      .replace(/\-+/g, ' ')
+      .replace(/[^\w\s]/g, '')
+      .split(' ')
+      .map((s: string) => (s[0]?.toUpperCase() || '') + (s.slice(1) || ''))
+      .join('')
   }
 
 


### PR DESCRIPTION
When writing a type alias for the generated TS type from the schema `title`, ensure the identifier derived from the title is a valid TS variable identifier by stripping out non alphanum characters and converting it to PascalCase.