### PR TITLE
fix(cli): warn for invalid files instead of halt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
If the CLI encounters an invalid file (non-JSON/YAML, e.g. a .DS_Store file), it throws and stops execution, forcing the offending file to be fixed or moved. This changes the default behavior to log a warning for this situation, rather than an uncaught exception.