### PR TITLE
feat(json-schema): add ability to set global custom ajv options

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ export function removeAdditonalProperties(input: ApiResponse): ApiResponse|never
   return input
 }
 ```
+
+##### Using custom `ajv` options
+
+To set custom [ajv options](https://ajv.js.org/options.html) for all JSONSchema instances, use the static `JSONSchema.setAjvOptions(options)` method. These options will override the default options. This method must be called before any instances have been used for validation to ensure that the options are applied.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -731,4 +731,36 @@ describe('JSONSchema', () => {
       expect(mockFn).toBeCalled()
     })
   })
+
+  describe('setAjvOptions', () => {
+    it('sets the ajv options for each instance', () => {
+      const jsonSchema1 = new JSONSchema({
+        type: 'string',
+        minLength: 1,
+        pattern: 'abc'
+      })
+
+      const jsonSchema2 = new JSONSchema({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          a: { type: 'number' }
+        }
+      })
+
+      expect(jsonSchema1.validate('').errors).toHaveLength(2)
+      expect(jsonSchema2.validate({
+        a: 'not a number',
+        b: 'not allowed',
+      }).errors).toHaveLength(2)
+
+      JSONSchema.setAjvOptions({ allErrors: false })
+
+      expect(jsonSchema1.validate('').errors).toHaveLength(1)
+      expect(jsonSchema2.validate({
+        a: 'not a number',
+        b: 'not allowed',
+      }).errors).toHaveLength(1)
+    })
+  })
 })


### PR DESCRIPTION
This allows consuming projects to specify their own ajv options when using generated JSONSchema classes.