### PR TITLE
feat(json-schema): add option to remove error reports for null in oneOf/anyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,10 @@ export function removeAdditonalProperties(input: ApiResponse): ApiResponse|never
 ##### Using custom `ajv` options
 
 To set custom [ajv options](https://ajv.js.org/options.html) for all JSONSchema instances, use the static `JSONSchema.setAjvOptions(options)` method. These options will override the default options. This method must be called before any instances have been used for validation to ensure that the options are applied.
+
+##### JSONSchema global options
+
+To set global JSONSchema options, use the static `JSONSchema.setOptions(options)` method. These options will be used by all instances of JSONSchema.
+
+Options:
+- `omitNullSiblingErrors` - do not report any errors related to failed `oneOf` or `anyOf` error when one of the child errors is `type must be null`. Only report errors against the non-`"type": "null"` child schemas.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kong/brij",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "build responsively in json-schema",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/json-schema.base.test.ts
+++ b/src/lib/json-schema.base.test.ts
@@ -1010,7 +1010,7 @@ describe('JSONSchema', () => {
           ])
         }
       })
-      it('omits null sibling errors for oneOf/anyOf', () => {
+      it('omits nested null sibling errors for oneOf/anyOf', () => {
         const jsonSchemaOneOf = new JSONSchema({
           type: 'object',
           oneOf: [

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -140,18 +140,18 @@ export class JSONSchema {
   }
 
   private removeNullSiblingErrors(errors: ErrorObject<string, Record<string, any>, unknown>[]) {
-    const schemaPathsPrefixesToCheck: [string, number][] = []
+    const schemaPathPrefixesToCheck: [string, number][] = []
     const errorsToRemove: number[] = []
 
     errors.forEach((error, index) => {
       if (['anyOf', 'oneOf'].includes(error.keyword)) {
-        schemaPathsPrefixesToCheck.push([error.schemaPath, index])
+        schemaPathPrefixesToCheck.push([error.schemaPath, index])
       }
     })
 
-    if (schemaPathsPrefixesToCheck.length) {
+    if (schemaPathPrefixesToCheck.length) {
       errors.forEach((error, index) => {
-        for (const [prefix, parentIndex] of schemaPathsPrefixesToCheck) {
+        for (const [prefix, parentIndex] of schemaPathPrefixesToCheck) {
           if (error.schemaPath.startsWith(prefix)) {
             const remainder = error.schemaPath.replace(prefix, '')
             if (remainder.match(/^\/[0-9]+\/type$/) && error.keyword === 'type' && error.params.type === 'null') {

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -161,11 +161,13 @@ export class JSONSchema {
           }
         }
       })
+
+      return errors.filter((_, index) => {
+        return !errorsToRemove.includes(index)
+      })
     }
 
-    return errors.filter((_, index) => {
-      return !errorsToRemove.includes(index)
-    })
+    return errors
   }
 
   /**

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -140,7 +140,6 @@ export class JSONSchema {
   }
 
   private removeNullSiblingErrors(errors: ErrorObject<string, Record<string, any>, unknown>[]) {
-
     const schemaPathsPrefixesToCheck: [string, number][] = []
     const errorsToRemove: number[] = []
 

--- a/src/lib/json-schema.base.ts
+++ b/src/lib/json-schema.base.ts
@@ -206,7 +206,7 @@ export class JSONSchema {
     const valid = removeAdditionalFunction(o)
 
     const error = new RemoveAdditionalPropsError(
-      removeAdditionalFunction.errors,
+      this.prepareErrors(removeAdditionalFunction.errors),
       this.schema
     )
 


### PR DESCRIPTION
This provides a new static method `JSONSchema.setOptions(options)` which applies options to all JSONSchema instances.

The first option is `omitNullSiblingErrors` which is described in the README and tests.