### PR TITLE
ci: publish @kong/brij on merge to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
-# NPM publish: add repository secret NPM_TOKEN (automation token with publish rights to @kong/brij).
+# NPM publish: uses npm Trusted Publishing (OIDC). No NPM_TOKEN secret required.
+# Requires npm >= 11.5.1 and the `id-token: write` permission on the publish job.
 name: CI
 on:
   push:
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
@@ -41,16 +43,15 @@ jobs:
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
-          always-auth: true
+      - name: Upgrade npm for Trusted Publishing (OIDC)
+        run: npm install -g npm@latest
       - run: yarn install --frozen-lockfile
       - name: Bump patch version
         run: npm version patch --no-git-tag-version
       - run: yarn build
       - run: yarn bundle:cli
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --ignore-scripts
+        run: npm publish --access restricted --ignore-scripts
       - name: Commit and push version bump
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,13 @@
+# NPM publish: add repository secret NPM_TOKEN (automation token with publish rights to @kong/brij).
 name: CI
 on:
   push:
     branches: [ main ]
   pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -21,3 +26,36 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test
+
+  publish:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.org
+          always-auth: true
+      - run: yarn install --frozen-lockfile
+      - name: Bump patch version
+        run: npm version patch --no-git-tag-version
+      - run: yarn build
+      - run: yarn bundle:cli
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --ignore-scripts
+      - name: Commit and push version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          VER=$(node -p "require('./package.json').version")
+          git commit -m "chore: release v${VER} [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Upgrade npm for Trusted Publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
       - run: yarn install --frozen-lockfile
       - name: Bump patch version
         run: npm version patch --no-git-tag-version


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to add automated publishing to npm when changes are pushed to the `main` branch. It also introduces concurrency controls to prevent overlapping workflow runs.

Workflow automation improvements:

* Added a new `publish` job to `.github/workflows/ci.yaml` that runs after `build` and publishes the package to npm when a push occurs to `main`. This job handles version bumping, building, bundling, publishing to npm, and committing the version bump back to the repository.
* Publishing uses **npm Trusted Publishing (OIDC)** rather than a long-lived `NPM_TOKEN` secret (requires `id-token: write` and npm >= 11.5.1).
* Package is published with `--access restricted` to keep it private on npmjs, matching its current registry setting.
* Introduced concurrency controls to the workflow to ensure only one workflow run per branch/reference is active at a time, canceling in-progress runs for pull requests.

Notes:
- No `NPM_TOKEN` secret is needed — OIDC Trusted Publishing must be configured for `@kong/brij` on npmjs.com pointing at the `Kong/brij` repo + `ci.yaml` workflow.