### PR TITLE
ci: bump Node to 20/22 for npm Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381
         with:
-          node-version: 18.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org
       - name: Upgrade npm for Trusted Publishing (OIDC)
         run: npm install -g npm@^11.5.1


### PR DESCRIPTION
## Why

The publish job added in #30 uses npm Trusted Publishing (OIDC), which requires npm >= 11.5.1. That npm version requires Node `^20.17.0 || >=22.9.0`, so the CI run failed on Node 18:

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: npm@11.16.0
npm error Required: {"node":"^20.17.0 || >=22.9.0"}
npm error Actual:   {"npm":"10.8.2","node":"v18.20.8"}
```

## Changes

* Publish job: Node 18.x → **22.x**.
* Build/test matrix: `[16.x, 18.x]` → **`[20.x, 22.x]`** (16 and 18 are both EOL).

No `engines` field or `.nvmrc` exists, so nothing else needs to stay in sync.