### PR TITLE
ci: set publishConfig.access=restricted to fix publish 404

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Upgrade npm for Trusted Publishing (OIDC)
         run: npm install -g npm@^11.5.1
+      - name: Verify npm version
+        run: npm --version
       - run: yarn install --frozen-lockfile
       - name: Bump patch version
         run: npm version patch --no-git-tag-version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - run: yarn build
       - run: yarn bundle:cli
       - name: Publish to npm
-        run: npm publish --access restricted --ignore-scripts
+        run: npm publish --ignore-scripts
       - name: Commit and push version bump
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       - run: yarn build
       - run: yarn bundle:cli
       - name: Publish to npm
-        run: npm publish --ignore-scripts
+        run: npm publish --access restricted --ignore-scripts
       - name: Commit and push version bump
         run: |
           git config user.name "github-actions[bot]"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kong/brij"
+    "url": "https://github.com/Kong/brij"
   },
   "publishConfig": {
     "access": "restricted"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/kong/brij"
   },
+  "publishConfig": {
+    "access": "restricted"
+  },
   "bin": {
     "brij": "bin/cli.js"
   },


### PR DESCRIPTION
## Why

The publish job ran but failed with:

```
npm error 404 The requested resource '@kong/brij@0.1.16' could not be
found or you do not have permission to access it.
```

Per @ValeryG's suggestion (matching [shared-ui-components](https://github.com/kong-konnect/shared-ui-components/blob/main/packages/core/konnect-app-shell/package.json#L22-L24)), declaring the access level in `package.json` rather than only via a CLI flag.

## Changes

* Add `publishConfig.access: "restricted"` to `package.json` — keeps the package private and makes the access level explicit at publish time.
* Drop the now-redundant `--access restricted` flag from the `npm publish` step so access is defined in one place.

Package stays published privately on npmjs, consistent with the earlier decision in #30.